### PR TITLE
Minor improvements to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,15 @@
 # About
 
-This folder stores php code used to communicate
-with Vivo in order to generate "business cards"
+This repository stores php code used to communicate
+with [VIVO](http://github.com/vivo-project/vivo) in order to generate "business cards"
 displayed by the wordpress.
 
 Examples:
 
 * http://www.ctsi.ufl.edu/about/management/clinical-research-unit-directors/
-* http://www.ctsi.ufl.edu/about/management/uf-ctsi-leadership/
+* http://www.ctsi.ufl.edu/about/management/program-directors/
 * http://www.ctsi.ufl.edu/about/management/core-lab-directors/
 * http://www.ctsi.ufl.edu/about/management/clinical-research-unit-directors/
-
-* http://test.ctsi.ufl.edu/about/management/clinical-research-unit-directors/
 
 # Installation
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # About
 
-This repository stores php code used to communicate
-with [VIVO](http://github.com/vivo-project/vivo) in order to generate "business cards"
-displayed by the wordpress.
+This repository stores php code used to communicate with [VIVO](http://github.com/vivo-project/vivo) in order to generate "business cards" displayed by the wordpress.
 
 Examples:
 


### PR DESCRIPTION
Removed two examples (one was not VIVO, one pointed at a test instance) and added one.  Changed wording "folder" to "repository." "Added link to VIVO repository.  Changed VIVO to all caps.
